### PR TITLE
Fix multiple bugs

### DIFF
--- a/rplugin/python3/deoplete/sources/minisnip.py
+++ b/rplugin/python3/deoplete/sources/minisnip.py
@@ -1,4 +1,6 @@
 import os
+import re
+
 from .base import Base
 
 class Source(Base):
@@ -9,14 +11,25 @@ class Source(Base):
         self.name = 'minisnip'
         self.mark = '[minisnip]'
         self.min_pattern_length = 0
-        self.minisnip_dir = self.vim.eval('g:minisnip_dir')
-        self.snippets = os.listdir(os.path.expanduser(self.minisnip_dir))
+        self.minisnip_dir = None
+        self.snippets = []
 
     def gather_candidates(self, context):
-        """Returns all snippets in the users
-        vim minisnip directory"""
-        filetype = '_' + context['filetype'] + '_'
+        if not self.minisnip_dir:
+            self.minisnip_dir = self.vim.eval('g:minisnip_dir')
+            self.snippets = os.listdir(os.path.expanduser(self.minisnip_dir))
 
-        cleaned = [snippet.split(filetype)[1] for snippet in self.snippets if filetype in snippet]
-        return [{'word': snippet} for snippet in cleaned]
+        ft = context['filetype']
+        ft_reg = '^_(' + format(ft.replace('.', '|')) + ')_'
 
+        candidates = []
+
+        for snippet in self.snippets:
+            if snippet.startswith('_'):
+                m = re.search(ft_reg, snippet)
+                if m:
+                    candidates.append(snippet[len(m.group(0)):])
+            else:
+                candidates.append(snippet)
+
+        return [{'word': c} for c in candidates]

--- a/rplugin/python3/deoplete/sources/minisnip.py
+++ b/rplugin/python3/deoplete/sources/minisnip.py
@@ -20,7 +20,12 @@ class Source(Base):
             self.snippets = os.listdir(os.path.expanduser(self.minisnip_dir))
 
         ft = context['filetype']
-        ft_reg = '^_(' + format(ft.replace('.', '|')) + ')_'
+
+        # Converts compound filetypes into a prefix pattern.
+        # (`ruby.rspec` → `^_(ruby|rspec)_`)
+        #
+        # @see https://github.com/joereynolds/vim-minisnip/blob/b5bcaff0ddea13d3ce2cf25f4dc88b0569da60b1/autoload/minisnip.vim#L14-L20
+        ft_reg = '^_(' + ft.replace('.', '|') + ')_'
 
         candidates = []
 


### PR DESCRIPTION
## What

- Defer the evaluation of `g:minisnip_dir`. (Making it work properly with lazy plugin loading.)
- Improve filtering logic for compound filetypes. (`ft=ruby.rspec` must filter snippets prefixed with `_ruby_` and `_rspec_`.)
- Support global snippets which filename doesn't start with `_`.